### PR TITLE
ResNet50 changes to handle OMP and KMP params set via environment vars properly

### DIFF
--- a/benchmarks/image_recognition/tensorflow/resnet50/inference/fp32/model_init.py
+++ b/benchmarks/image_recognition/tensorflow/resnet50/inference/fp32/model_init.py
@@ -54,18 +54,19 @@ class ModelInitializer(BaseModelInitializer):
         arg_parser.add_argument("--steps", dest='steps',
                                 type=int, default=50,
                                 help="number of steps")
-        arg_parser.add_argument(
-            '--kmp-blocktime', dest='kmp_blocktime',
-            help='number of kmp block time',
-            type=int, default=1)
+        #arg_parser.add_argument(
+        #    '--kmp-blocktime', dest='kmp_blocktime',
+        #    help='number of kmp block time',
+        #    type=int, default=1)
 
         self.args = arg_parser.parse_args(self.custom_args, namespace=self.args)
 
         # Set KMP env vars, if they haven't already been set, but override the default KMP_BLOCKTIME value
         config_file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "config.json")
-        self.set_kmp_vars(config_file_path, kmp_blocktime=str(self.args.kmp_blocktime))
+        #self.set_kmp_vars(config_file_path, kmp_blocktime=str(self.args.kmp_blocktime))
+        self.set_kmp_vars(config_file_path)
 
-        set_env_var("OMP_NUM_THREADS", self.args.num_intra_threads)
+        set_env_var("OMP_NUM_THREADS", self.args.num_intra_threads, overwrite_existing=False)
 
         benchmark_script = os.path.join(
             self.args.intelai_models, self.args.mode,

--- a/benchmarks/image_recognition/tensorflow/resnet50/inference/int8/model_init.py
+++ b/benchmarks/image_recognition/tensorflow/resnet50/inference/int8/model_init.py
@@ -37,7 +37,7 @@ class ModelInitializer(BaseModelInitializer):
         # Set the num_inter_threads and num_intra_threads
         self.set_num_inter_intra_threads()
         # Set env vars, if they haven't already been set
-        set_env_var("OMP_NUM_THREADS", self.args.num_intra_threads, overwrite_existing=True)
+        set_env_var("OMP_NUM_THREADS", self.args.num_intra_threads, overwrite_existing=False)
 
     def parse_args(self):
         parser = argparse.ArgumentParser()
@@ -49,10 +49,10 @@ class ModelInitializer(BaseModelInitializer):
             "--steps", dest="steps",
             help="number of steps",
             type=int, default=50)
-        parser.add_argument(
-            '--kmp-blocktime', dest='kmp_blocktime',
-            help='number of kmp block time',
-            type=int, default=1)
+        #parser.add_argument(
+        #    '--kmp-blocktime', dest='kmp_blocktime',
+        #    help='number of kmp block time',
+        #    type=int, default=1)
         parser.add_argument(
             "--calibration-only",
             help="Calibrate the accuracy.",
@@ -67,7 +67,8 @@ class ModelInitializer(BaseModelInitializer):
                                       namespace=self.args)
         # Set KMP env vars, if they haven't already been set, but override the default KMP_BLOCKTIME value
         config_file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "config.json")
-        self.set_kmp_vars(config_file_path, kmp_blocktime=str(self.args.kmp_blocktime))
+        #self.set_kmp_vars(config_file_path, kmp_blocktime=str(self.args.kmp_blocktime))
+        self.set_kmp_vars(config_file_path)
 
     def run_benchmark_or_accuracy(self):
         cmd = os.path.join(

--- a/benchmarks/image_recognition/tensorflow/resnet50v1_5/inference/bfloat16/model_init.py
+++ b/benchmarks/image_recognition/tensorflow/resnet50v1_5/inference/bfloat16/model_init.py
@@ -54,16 +54,17 @@ class ModelInitializer(BaseModelInitializer):
         arg_parser.add_argument("--steps", dest='steps',
                                 type=int, default=50,
                                 help="number of steps")
-        arg_parser.add_argument(
-            '--kmp-blocktime', dest='kmp_blocktime',
-            help='number of kmp block time',
-            type=int, default=1)
+        #arg_parser.add_argument(
+        #    '--kmp-blocktime', dest='kmp_blocktime',
+        #    help='number of kmp block time',
+        #    type=int, default=1)
 
         self.args = arg_parser.parse_args(self.custom_args, namespace=self.args)
 
         # Set KMP env vars, if they haven't already been set, but override the default KMP_BLOCKTIME value
         config_file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "config.json")
-        self.set_kmp_vars(config_file_path, kmp_blocktime=str(self.args.kmp_blocktime))
+        #self.set_kmp_vars(config_file_path, kmp_blocktime=str(self.args.kmp_blocktime))
+        self.set_kmp_vars(config_file_path)
 
         set_env_var("OMP_NUM_THREADS", self.args.num_intra_threads)
 

--- a/benchmarks/image_recognition/tensorflow/resnet50v1_5/inference/fp32/model_init.py
+++ b/benchmarks/image_recognition/tensorflow/resnet50v1_5/inference/fp32/model_init.py
@@ -54,16 +54,17 @@ class ModelInitializer(BaseModelInitializer):
         arg_parser.add_argument("--steps", dest='steps',
                                 type=int, default=50,
                                 help="number of steps")
-        arg_parser.add_argument(
-            '--kmp-blocktime', dest='kmp_blocktime',
-            help='number of kmp block time',
-            type=int, default=1)
+        #arg_parser.add_argument(
+        #    '--kmp-blocktime', dest='kmp_blocktime',
+        #    help='number of kmp block time',
+        #    type=int, default=1)
 
         self.args = arg_parser.parse_args(self.custom_args, namespace=self.args)
 
         # Set KMP env vars, if they haven't already been set, but override the default KMP_BLOCKTIME value
         config_file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "config.json")
-        self.set_kmp_vars(config_file_path, kmp_blocktime=str(self.args.kmp_blocktime))
+        #self.set_kmp_vars(config_file_path, kmp_blocktime=str(self.args.kmp_blocktime))
+        self.set_kmp_vars(config_file_path)
 
         set_env_var("OMP_NUM_THREADS", self.args.num_intra_threads)
 

--- a/benchmarks/image_recognition/tensorflow/resnet50v1_5/inference/int8/model_init.py
+++ b/benchmarks/image_recognition/tensorflow/resnet50v1_5/inference/int8/model_init.py
@@ -37,7 +37,7 @@ class ModelInitializer(BaseModelInitializer):
         # Set the num_inter_threads and num_intra_threads
         self.set_num_inter_intra_threads()
         # Set env vars, if they haven't already been set
-        set_env_var("OMP_NUM_THREADS", self.args.num_intra_threads, overwrite_existing=True)
+        set_env_var("OMP_NUM_THREADS", self.args.num_intra_threads, overwrite_existing=False)
 
     def parse_args(self):
         parser = argparse.ArgumentParser()
@@ -49,10 +49,10 @@ class ModelInitializer(BaseModelInitializer):
             "--steps", dest="steps",
             help="number of steps",
             type=int, default=50)
-        parser.add_argument(
-            '--kmp-blocktime', dest='kmp_blocktime',
-            help='number of kmp block time',
-            type=int, default=1)
+        #parser.add_argument(
+        #    '--kmp-blocktime', dest='kmp_blocktime',
+        #    help='number of kmp block time',
+        #    type=int, default=1)
         parser.add_argument(
             "--calibration-only",
             help="Calibrate the accuracy.",
@@ -68,9 +68,8 @@ class ModelInitializer(BaseModelInitializer):
 
         # Set KMP env vars, if they haven't already been set, but override the default KMP_BLOCKTIME value
         config_file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "config.json")
-        self.set_kmp_vars(config_file_path, kmp_blocktime=str(self.args.kmp_blocktime))
-
-        set_env_var("OMP_NUM_THREADS", self.args.num_intra_threads)
+        #self.set_kmp_vars(config_file_path, kmp_blocktime=str(self.args.kmp_blocktime))
+        self.set_kmp_vars(config_file_path)
 
     def run_benchmark_or_accuracy(self):
         cmd = os.path.join(


### PR DESCRIPTION
Changes ensure that OMP and KMP params set via environment vars get highest precedence and are not overwritten by benchmark scripts. Changes ensure that if the following environment variables are not set then they are set by the script. If the variables are set, then benchmarking scripts do not overwrite them.

OMP_NUM_THREADS: default is same as num-intra-threads
KMP_BLOCKTIME: default is 1
KMP_AFFINITY: "granularity=fine,verbose,compact,1,0"
KMP_SETTINGS: default is 1